### PR TITLE
fixing comment toggle hotkey

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -137,6 +137,8 @@
     nnoremap <Leader>h :noh<return>
     nnoremap <Leader>O O<Esc>
     nnoremap <Leader>o o<Esc>
+    nnoremap <Leader><Leader> :call NERDComment("n", "Toggle")<return>
+    vnoremap <Leader><Leader> :call NERDComment("v", "Toggle")<return>
     nnoremap <S-Down> 10j
     nnoremap <S-Up> 10k
     imap <S-Down> <Esc>10ji

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Keybindings and Commands
 
 The below mappings are default in NERDCommenter, and the ones most used, so they are included in our README.
 
-* **,c[spacebar]** *Toggles comment state of the selected line(s)*
+* **,,** *Toggles comment state of the selected line(s)*
 * **,cl** *Comment current line or text selected in visual mode (forces nesting)*
 * **,cu** *Uncomment selected lines(s)*
 


### PR DESCRIPTION
idk if this thing will merge nicely, enjoy

Conflicts:

```
.vimrc
```
