### PR TITLE
Making the copy buffer infinity

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -50,6 +50,8 @@
     set shellcmdflag=-ic
     " Use bash for the shell
     set shell=/bin/bash\ -i
+    " Set the copy buffer to infinity
+    match OverLength /\%101v.\+/
     " Re-open VIM to the last spot you had open.
     if has("autocmd")
         au BufReadPost * if line("'\"") > 0 && line("'\"") <= line("$")


### PR DESCRIPTION
It's currently limited to 50 lines.

Reference: http://vim.1045645.n5.nabble.com/problem-vim-can-only-yank-for-50-lines-in-vim-td3231985.html
