### PR TITLE
Adding an ignore file so stow won't symlink stuff

### DIFF
--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -1,0 +1,5 @@
+README.*
+\.git
+\.gitmodules
+\.gitignore
+Inconsolata.otf


### PR DESCRIPTION
This skips symlinking the font file and the readme when running gnu stow.
