### PR TITLE
Turn off pymode's max line length

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -392,6 +392,7 @@
     let g:pymode_syntax_all = 1
     let g:pymode_syntax_print_as_function = 1
     let g:pymode_syntax = 1
+    let g:pymode_options_max_line_length = 0
 
     " Snippet settings
     let g:UltiSnipsExpandTrigger="<c-e>"


### PR DESCRIPTION
This puts an anonoying red line at 81 characters by default.
