### PR TITLE
Set right margin to 50 characters for git commits.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -454,6 +454,7 @@
     autocmd FileType javascript vnoremap <buffer>  <c-f> :call RangeJsBeautify()<cr>
     autocmd FileType html vnoremap <buffer> <c-f> :call RangeHtmlBeautify()<cr>
     autocmd FileType css vnoremap <buffer> <c-f> :call RangeCSSBeautify()<cr>
+    autocmd FileType gitcommit setlocal colorcolumn=50
 
     au BufNewFile,BufRead *.wsgi set filetype=python
     augroup golang_au


### PR DESCRIPTION
I like having right margins set for files, but my personal default of 80 was annoying when editing git commits.
So, I set a right margin of 50 characters just for gitcommit files.
This should also give people more of a hint as to how much space they have left when writing commit messages. :smiley: 

![screen shot 2014-08-07 at 11 13 58 am](https://cloud.githubusercontent.com/assets/346877/3844986/268ebeb2-1e4e-11e4-94c4-2e8a69186b82.png)
